### PR TITLE
fix warning of `showOverlay` being a number

### DIFF
--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -108,7 +108,7 @@ class Dialog extends Component {
     let overlayPointerEvents;
 
     const dialogState = this.state.dialogState;
-    const isShowOverlay = (['opened', 'opening'].includes(dialogState) & this.props.haveOverlay);
+    const isShowOverlay = (['opened', 'opening'].includes(dialogState) && this.props.haveOverlay);
 
     if (this.props.overlayPointerEvents) {
       overlayPointerEvents = this.props.overlayPointerEvents;


### PR DESCRIPTION
typo using `&` instead of `&&' resulting the `isShowOverlay` becoming a number (hence the warning on passing a number to the `showOverlay` property when boolean is expected)