### PR TITLE
Partial Resolves issue #12 (Part 1)

### DIFF
--- a/src/components/Overlay.js
+++ b/src/components/Overlay.js
@@ -46,13 +46,14 @@ class Overlay extends Component {
     const { onPress, pointerEvents } = this.props;
     const backgroundColor = { backgroundColor: this.props.backgroundColor };
     const opacity = { opacity: this.state.opacity };
+    const dimensions = {width: Dimensions.get('window').width, height: Dimensions.get('window').height }
 
     return (
       <Animated.View
         pointerEvents={pointerEvents}
-        style={[styles.overlay, backgroundColor, opacity]}
+        style={[styles.overlay, backgroundColor, opacity, dimensions]}
       >
-        <TouchableOpacity onPress={onPress} style={[styles.overlay]} />
+        <TouchableOpacity onPress={onPress} style={[styles.overlay, dimensions]} />
       </Animated.View>
     );
   }
@@ -63,8 +64,6 @@ const styles = StyleSheet.create({
     flex: 1,
     top: 0,
     left: 0,
-    width: WIDTH,
-    height: HEIGHT,
     position: 'absolute',
   },
 });


### PR DESCRIPTION
Moving height/width into render resolves issue where overlay uses initial orientation dimensions instead of current orientation dimensions.  

If the overlay is already open however, the issue is not resolved.