### PR TITLE
Change type to string to solve props validation warning

### DIFF
--- a/src/Type.js
+++ b/src/Type.js
@@ -6,7 +6,7 @@ export type PopupDialogType = {
 }
 
 export type DialogType = {
-  width?: number;
+  width?: string;
   height?: number;
   haveOverlay: boolean;
   overlayPointerEvents?: string;


### PR DESCRIPTION
If we use the props width with a string we will receive the following  message:
ExceptionsManager.js:73 Warning: Failed prop type: Invalid prop `width` of type `string` supplied to `Dialog`, expected `number`. in Dialog (at PopupDialog.js:23)
But in this way everything works fine.
However if we use with as number we get this error:
JSON value '90' of type NSString cannot be converted to a YGValue. Did you forget the % or pt suffix?
And break the app.