### PR TITLE
Fix Animation instance incorrectly shared

### DIFF
--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -74,7 +74,6 @@ class Dialog extends Component<DialogProps, State> {
     actionsBordered: true,
     animationDuration: DEFAULT_ANIMATION_DURATION,
     dialogStyle: null,
-    dialogAnimation: new FadeAnimation({ animationDuration: DEFAULT_ANIMATION_DURATION }),
     width: null,
     height: null,
     onTouchOutside: () => {},
@@ -93,7 +92,7 @@ class Dialog extends Component<DialogProps, State> {
     super(props);
 
     this.state = {
-      dialogAnimation: props.dialogAnimation,
+      dialogAnimation: props.dialogAnimation || new FadeAnimation({ animationDuration: DEFAULT_ANIMATION_DURATION }),
       dialogState: DIALOG_CLOSED,
     };
   }


### PR DESCRIPTION
Fix bug where Animation instance is incorrectly shared between components when user did not provide an explicit dialogAnimation. 

This would cause multiple dialogs to be dismissed together, even though only one of them is actually suppose to be dismissed.

This is because defaultProps are created once and then passed in to components by reference. Instead we can default to creating a new animation in the constructor if user did not pass it in. 