### PR TITLE
Prevent sibling from being created more than once

### DIFF
--- a/src/PopupDialog.js
+++ b/src/PopupDialog.js
@@ -53,7 +53,10 @@ export default class PopupDialog extends Component<DialogProps, State> {
   sibling: Sibling = null
 
   createDialog() {
-    this.sibling = new Sibling(this.renderDialog());
+    // Protect against setState happening asynchronously
+    if (!this.sibling) {
+      this.sibling = new Sibling(this.renderDialog());
+    }
   }
 
   updateDialog() {


### PR DESCRIPTION
This can happen because setState can be async. Therefore multiple dialogs would end up getting rendered when `componentDidUpdate` is called multiple times during a single render cycle. See https://medium.com/@wereHamster/beware-react-setstate-is-asynchronous-ce87ef1a9cf3