### PR TITLE
proper onHardwareBackPress example

### DIFF
--- a/popup-dialog-example/App.js
+++ b/popup-dialog-example/App.js
@@ -160,6 +160,9 @@ export default class App extends Component {
           dialogAnimation={new ScaleAnimation()}
           onHardwareBackPress={() => {
             console.log('onHardwareBackPress');
+            if (!this.state.scaleAnimationDialog) {
+              return false;
+            }
             this.setState({ scaleAnimationDialog: false });
             return true;
           }}


### PR DESCRIPTION
I think onHardwareBackPress mostly are used for dismiss the dialog, and should do nothing after the dialog is dismissed.