### PR TITLE
Fix "Buttom" typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ yarn add react-native-modals
 ## Exposed Modules
 
 * Modal
-* ButtomModal
+* ButtonModal
 * ModalPortal
 * Backdrop
 * ModalButton


### PR DESCRIPTION
This PR fixes a typo under the Exposed Modules section "ButtomModal"